### PR TITLE
BASIC 認証を追加

### DIFF
--- a/next/.env
+++ b/next/.env
@@ -1,4 +1,5 @@
-
+BASIC_AUTH_USER='test'
+BASIC_AUTH_PASSWORD='password'
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
 

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const { BASIC_AUTH_USER, BASIC_AUTH_PASSWORD } = process.env
+
+export const config = {
+  matcher: ['/'],
+}
+
+export const middleware = (req: NextRequest) => {
+  const basicAuth = req.headers.get('authorization')
+  const url = req.nextUrl
+
+  if (basicAuth) {
+    const authValue = basicAuth.split(' ')[1]
+    const [user, pwd] = atob(authValue).split(':')
+
+    if (user === BASIC_AUTH_USER && pwd === BASIC_AUTH_PASSWORD) {
+      return NextResponse.next()
+    }
+  }
+  url.pathname = '/api/auth'
+
+  return NextResponse.rewrite(url)
+}

--- a/next/src/pages/api/auth.ts
+++ b/next/src/pages/api/auth.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const handler = (_: NextApiRequest, res: NextApiResponse) => {
+  res.setHeader('WWW-authenticate', 'Basic realm="Secure Area"')
+  res.statusCode = 401
+  res.end(`Auth Required.`)
+}
+
+export default handler


### PR DESCRIPTION
## 関連する Issue
- https://github.com/tramaru/hikido/issues/47

## やったこと
- BASIC 認証を設定
    - https://github.com/vercel/examples/tree/main/edge-functions/basic-auth-password 

## 動作確認
- `http://localhost:3000/` にアクセスして BASIC 認証が効いていること
