### PR TITLE
AWS の環境変数名を変更

### DIFF
--- a/next/.env
+++ b/next/.env
@@ -7,3 +7,6 @@ BASIC_AUTH_PASSWORD='password'
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="mysql://root:password@mysql:3306/hikido_development?connect_timeout=30"
+HIKIDO_AWS_ACCESS_KEY_ID="sample"
+HIKIDO_AWS_SECRET_ACCESS_KEY="sample"
+HIKIDO_S3_BUCKET="sample"

--- a/next/src/pages/api/events/[id]/transcript.tsx
+++ b/next/src/pages/api/events/[id]/transcript.tsx
@@ -59,13 +59,13 @@ const fetchBucket = (key: string) => {
   const client = new S3Client({
     region: 'ap-northeast-1',
     credentials: {
-      accessKeyId: `${process.env.AWS_ACCESS_KEY_ID}`,
-      secretAccessKey: `${process.env.AWS_SECRET_ACCESS_KEY}`,
+      accessKeyId: `${process.env.HIKIDO_AWS_ACCESS_KEY_ID}`,
+      secretAccessKey: `${process.env.HIKIDO_AWS_SECRET_ACCESS_KEY}`,
     },
   });
 
   const command = new GetObjectCommand({
-    Bucket: `${process.env.S3_BUCKET}`,
+    Bucket: `${process.env.HIKIDO_S3_BUCKET}`,
     Key: key,
   });
 


### PR DESCRIPTION
## 概要

AWS_ACCEESS_KEY_ID などが vercel で予約されている環境変数だったため、アプリで使う際には変更する必要がありました。そのため変更しました。
ref: https://vercel.com/docs/concepts/projects/environment-variables#reserved-environment-variables

## やったこと

同上。

## やらなかったこと

本番鏡への反映。本番にデプロイする際には、各環境変数に本番で使う Access Key などを入れていただけますと〜。

## 動作確認方法

環境変数名を変えた状態で、文字起こしするボタンが機能することを確認してください。

## 参考

