### PR TITLE
Prisma インスタンスをグローバル化した

### DIFF
--- a/discord_bot/src/model/event.ts
+++ b/discord_bot/src/model/event.ts
@@ -1,7 +1,5 @@
 import type { Event } from '../types/Event'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '../../prisma/client'
 
 export type EventElement = Pick<Event, 'title' | 'audioUrl' | 'transcriptUrl' | 'transcript'>
 

--- a/next/src/pages/api/events.tsx
+++ b/next/src/pages/api/events.tsx
@@ -1,4 +1,5 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from 'prisma/client'
+import type { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next'
 import type { Event } from 'types/Event'
 
@@ -18,8 +19,6 @@ export default async function handler(
   }
 
   if (method !== 'GET') { return res.status(404) }
-
-  const prisma = new PrismaClient()
 
   try {
     const events = await findManyEventWithQuery(prisma, query)

--- a/next/src/pages/api/events/[id].tsx
+++ b/next/src/pages/api/events/[id].tsx
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client';
+import { prisma } from 'prisma/client';
 import type { Event } from 'types/Event';
 
 type Response = {
@@ -17,7 +17,6 @@ export default async function handler(
   if (method !== 'GET') { return res.status(404) }
   if (eventId === NaN) { return res.status(400).json({ error: 'eventId is required' }) }
 
-  const prisma = new PrismaClient()
   const event = await prisma.event.findUnique({
     where: {
       id: eventId

--- a/next/src/pages/api/events/[id]/transcript.tsx
+++ b/next/src/pages/api/events/[id]/transcript.tsx
@@ -1,8 +1,9 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'; // ES Modules import
-import { PrismaClient } from '@prisma/client';
+import { prisma } from 'prisma/client';
 import { Readable } from 'stream';
 import type { Event } from 'types/Event';
+import type { NextApiRequest, NextApiResponse } from 'next'
+import type { PrismaClient } from '@prisma/client'
 
 type Response = {
   event: Event | {}
@@ -19,7 +20,6 @@ export default async function handler(
   if (method !== 'PUT') { return res.status(404) }
   if (eventId === NaN) { return res.status(400).json({ event: {}, error: 'eventId is required' }) }
 
-  const prisma = new PrismaClient()
   const event = await prisma.event.findUnique({
     where: {
       id: eventId

--- a/next/src/prisma/client.ts
+++ b/next/src/prisma/client.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from '@prisma/client'
+
+declare global {
+  // allow global `var` declarations
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined
+}
+
+export const prisma = new PrismaClient({
+  log: [
+    {
+      emit: 'event',
+      level: 'query',
+    },
+    {
+      emit: 'stdout',
+      level: 'error',
+    },
+    {
+      emit: 'stdout',
+      level: 'info',
+    },
+    {
+      emit: 'stdout',
+      level: 'warn',
+    },
+  ],
+})
+
+prisma.$on('query', (e) => {
+  console.log('Query: ' + e.query)
+  console.log('Params: ' + e.params)
+  console.log('Duration: ' + e.duration + 'ms')
+})
+
+global.prisma = prisma

--- a/next/src/prisma/seed.ts
+++ b/next/src/prisma/seed.ts
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-const prisma = new PrismaClient();
+import { prisma } from './client';
 
 const eventData = [
   {


### PR DESCRIPTION
## 概要

close: #55

next/discord_bot ともに、Prisma インスタンスをグローバル化して、それを使い回すようにしました。
Prisma インスタンスは生成されると DB とのコネクションプールを管理します。そのため、複数のインスタンスが生成されるとコネクションプールの管理が複雑化します。

そのため、1つの prisma インスタンスを使い回すようにしました。

また、併せてログに SQL などを表示するようにしています。
本番環境でのデバッグをしやすくするためです。

## やらなかったこと

特にありません。

## 動作確認

- events 一覧ページ、検索機能、詳細画面の表示、文字起こし機能が動くことを確認しました
- discord_bot の方も、upload で DB の値が更新されることを確認しました

## 参考

- Prisma インスタンスのベストプラクティスについて
  - [Best practice for instantiating PrismaClient with Next\.js \| Prisma Docs](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices)

- ログについて
  - [Configuring logging \(Concepts\) \| Prisma Docs](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging)
