### PR TITLE
yarn build では Prisma 経由でマイグレーションを流せない問題を解決

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "vercel-build": "prisma generate && prisma migrate deploy && next build"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.171.0",


### PR DESCRIPTION
## やったこと
- vercel-build を追加
    - デプロイ時に migration が流れるようにした

### 詳細
- https://www.prisma.io/docs/guides/deployment/deployment-guides/deploying-to-vercel

## 動作確認
- `yarn vercel-build` が実行できること
```
% yarn vercel-build
``` 