### PR TITLE
検索フォームをからにした際に全件を取得するように修正

### DIFF
--- a/next/src/components/SearchForm.tsx
+++ b/next/src/components/SearchForm.tsx
@@ -5,7 +5,7 @@ import Grid from '@mui/material/Grid';
 
 type Search = (query: string) => void
 
-const SearchForm: React.FC<{ onClick: Search }> = ({ onClick}) => {
+const SearchForm: React.FC<{ onClick: Search }> = ({ onClick }) => {
   const [query, setQuery] = useState("")
 
   const fireSearchWhenPressedEnter = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -13,6 +13,11 @@ const SearchForm: React.FC<{ onClick: Search }> = ({ onClick}) => {
       onClick(query);
     }
   };
+
+  const handlerOnClear = (textValue: string) => {
+    if (!!textValue) return
+    onClick(textValue)
+  }
 
   return (
     <Grid container sx={{ width: "30%", mx: 'auto', mt: 2 }}>
@@ -24,7 +29,11 @@ const SearchForm: React.FC<{ onClick: Search }> = ({ onClick}) => {
           InputProps={{
             type: 'search',
           }}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            const value = e.target.value
+            setQuery(value)
+            handlerOnClear(value)
+          }}
           value={query}
           onKeyPress={(e) => {
             fireSearchWhenPressedEnter(e);


### PR DESCRIPTION
## 関連する Issue
- https://github.com/tramaru/hikido/issues/65

## やったこと
- 検索フォームが空になったときに、一覧取得イベントが発火するように変更した

## 詳細
Material UI の TextField API に onClear 的なイベントがなさそうだった
- https://mui.com/material-ui/api/text-field/

## 動作確認
- イベント一覧画面で、任意の項目で検索してください
    - http://localhost:3000/
- 検索後に文言をクリア or 削除することで、イベントを全件取得できるのを確認してください