### PR TITLE
最初にアクセスしたときに検索が遅い問題を解決する

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.10.4",
     "@prisma/client": "4.2.1",
     "next": "^12.3.1",
+    "next-absolute-url": "^1.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.1"

--- a/next/src/hooks/useSearchEvent.tsx
+++ b/next/src/hooks/useSearchEvent.tsx
@@ -1,17 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Event } from 'types/Event'
 
-const useSearchEvent = (): [Event[] | [], (keyword: string) => void] => {
-  const [events, setEvents] = useState<Event[] | []>([]);
-
-  useEffect(() => {
-    const fetchEvents = async () => {
-      const response = await fetch('/api/events');
-      const { events } = await response.json();
-      setEvents(events);
-    };
-    fetchEvents();
-  }, []);
+const useSearchEvent = (initialEvents: Event[]): [Event[] | [], (keyword: string) => void] => {
+  const [events, setEvents] = useState<Event[] | []>(initialEvents);
 
   const search = async (keyword: string) => {
     const response = await fetch(`/api/events?q=${keyword}`);

--- a/next/src/pages/api/events.tsx
+++ b/next/src/pages/api/events.tsx
@@ -4,8 +4,8 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import type { Event } from 'types/Event'
 
 type Response = {
-  events: Event[] | []
-  error?: string
+  events: Event[] | null
+  error: string | null
 }
 
 export default async function handler(
@@ -22,10 +22,10 @@ export default async function handler(
 
   try {
     const events = await findManyEventWithQuery(prisma, query)
-    res.status(200).json({ events: events })
-  } catch(error: any) {
+    res.status(200).json({ events: events, error: null })
+  } catch (error: any) {
     console.error(error.message)
-    res.status(500).json({ events: [], error: error.message })
+    res.status(500).json({ events: null, error: error.message })
   } finally {
     prisma.$disconnect();
   }

--- a/next/src/pages/api/events/[id].tsx
+++ b/next/src/pages/api/events/[id].tsx
@@ -3,8 +3,8 @@ import { prisma } from 'prisma/client';
 import type { Event } from 'types/Event';
 
 type Response = {
-  event?: Event
-  error?: String
+  event: Event | null
+  error: String | null
 }
 
 export default async function handler(
@@ -15,7 +15,7 @@ export default async function handler(
   const eventId = Number(req.query.id)
 
   if (method !== 'GET') { return res.status(404) }
-  if (eventId === NaN) { return res.status(400).json({ error: 'eventId is required' }) }
+  if (eventId === NaN) { return res.status(400).json({ event: null, error: 'eventId is required' }) }
 
   const event = await prisma.event.findUnique({
     where: {
@@ -25,7 +25,7 @@ export default async function handler(
 
   prisma.$disconnect();
 
-  if (event === null) { return res.status(404).json({ error: 'event not found' })}
+  if (event === null) { return res.status(404).json({ event: null, error: 'event not found' }) }
 
-  res.status(200).json({ event: event })
+  res.status(200).json({ event: event, error: null })
 }

--- a/next/src/pages/events/[id].tsx
+++ b/next/src/pages/events/[id].tsx
@@ -3,32 +3,14 @@ import ErrorMessage from 'components/ErrorMessage';
 import EventDetail from 'components/EventDetail';
 import Grid from '@mui/material/Grid';
 
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import type { Event } from 'types/Event';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
+import absoluteUrl from 'next-absolute-url';
 
-const EventPage: NextPage = () => {
-  const [event, setEvent] = useState<Event | undefined>()
-  const [error, setError] = useState<boolean>()
-  const router = useRouter()
-  const { id: eventId } = router.query
-
-  useEffect(() => {
-    if (!eventId) return
-    const fetchEvent = async () => {
-      const response = await fetch(`/api/events/${eventId}`)
-      const { event: fetchedEvent, error: fetchedError } = await response.json()
-      setError(!!fetchedError)
-      setEvent(fetchedEvent)
-    }
-
-    fetchEvent()
-  }, [eventId])
-
+const EventPage: NextPage<{ event: Event, error: string }> = ({ event, error }) => {
   return (
     <Grid container spacing={2} sx={{ mt: 1 }}>
-      {error && (
+      {!!error && (
         <Box mb={1.5}>
           <ErrorMessage />
         </Box>
@@ -38,4 +20,13 @@ const EventPage: NextPage = () => {
   );
 }
 
-export default EventPage
+const getServerSideProps: GetServerSideProps = async (context) => {
+  const { origin } = absoluteUrl(context.req)
+  const { id } = context.query
+  const response = await fetch(`${origin}/api/events/${id}`);
+  const { event, error } = await response.json()
+
+  return ({ props: { event, error } })
+}
+
+export { EventPage as default, getServerSideProps }

--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -1,16 +1,23 @@
 import EventList from 'components/EventList';
 import SearchForm from 'components/SearchForm';
 import useSearchEvent from 'hooks/useSearchEvent';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { Event } from 'types/Event';
-import type { NextPage } from 'next'
+import type { GetServerSideProps, NextPage } from 'next'
+import absoluteUrl from 'next-absolute-url';
+import ErrorMessage from 'components/ErrorMessage';
 
-const Home: NextPage = () => {
-  const [events, search] = useSearchEvent()
+const Home: NextPage<{ fetchedEvents: Event[], fetchedError: string }> = ({ fetchedEvents, fetchedError }) => {
+  const [events, search] = useSearchEvent(fetchedEvents)
 
   return (
     <div>
       <SearchForm onClick={search} />
+      {!!fetchedError && (
+        <Box mb={1.5} mt={1.5}>
+          <ErrorMessage />
+        </Box>
+      )}
       {events.length == 0 && (
         <Typography component='h2' variant='h5' mt={6}>
           検索結果がありませんでした。
@@ -21,4 +28,12 @@ const Home: NextPage = () => {
   );
 }
 
-export default Home
+const getServerSideProps: GetServerSideProps = async (context) => {
+  const { origin } = absoluteUrl(context.req)
+  const response = await fetch(`${origin}/api/events`);
+  const { events: fetchedEvents, error: fetchedError } = await response.json()
+
+  return ({ props: { fetchedEvents, fetchedError } })
+}
+
+export { Home as default, getServerSideProps }

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -2610,6 +2610,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-absolute-url@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/next-absolute-url/-/next-absolute-url-1.2.2.tgz#9aba5adcee8effcffd63271d99e13213ad04c23b"
+  integrity sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg==
+
 next@^12.3.1:
   version "12.3.1"
   resolved "https://registry.yarnpkg.com/next/-/next-12.3.1.tgz#127b825ad2207faf869b33393ec8c75fe61e50f1"


### PR DESCRIPTION
## 関連する Issue
- https://github.com/tramaru/hikido/issues/63

## やったこと
- 初期表示時のイベント情報取得まわりを `getServerSideProps` を利用する形に変更した

## 結論
`getServerSideProps` を利用する方針が良いと考える
- 速度測定の結果から若干利用した方が速そうなため
- イベント一覧画面の初期表示時に要素が表示されるため

### 速度測定

getServerSideProps の利用の有無による変化を Chrome の Performance を利用して測定しました
- ただ、あまり測定結果が安定しなかったので、有意であるかは疑問がありますmm

| getServerSideProps | 利用する | 利用しない |
|---|---|---|
|1回目|1801 ms| 5369 ms
|2回目|7232 ms| 5261 ms
|3回目|1201 ms | 1052 ms
|平均| 3411 ms| 3894 ms

### 調べたこと
Basic 認証がなければこれが利用できそう
- https://pagespeed.web.dev/

手間をかければ、これで厳密な測定結果が出せそう
- https://nextjs-ja-translation-docs.vercel.app/docs/advanced-features/measuring-performance

## 動作確認
- イベント一覧と詳細画面が問題なく閲覧できること