### PR TITLE
文字起こしボタンを押したときにスピナーを出すようにした

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -13,6 +13,7 @@
     "@aws-sdk/client-s3": "^3.171.0",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@mui/lab": "^5.0.0-alpha.103",
     "@mui/material": "^5.10.4",
     "@prisma/client": "4.2.1",
     "next": "^12.3.1",

--- a/next/package.json
+++ b/next/package.json
@@ -13,6 +13,7 @@
     "@aws-sdk/client-s3": "^3.171.0",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@mui/icons-material": "^5.10.9",
     "@mui/lab": "^5.0.0-alpha.103",
     "@mui/material": "^5.10.4",
     "@prisma/client": "4.2.1",

--- a/next/src/components/EventCard.tsx
+++ b/next/src/components/EventCard.tsx
@@ -1,9 +1,11 @@
+import ActionButton from 'components/ActionButton'
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import ActionButton from 'components/ActionButton'
 import ErrorMessage from './ErrorMessage';
 import Grid from '@mui/material/Grid';
+import LoadingButton from '@mui/lab/LoadingButton';
+import SaveIcon from '@mui/icons-material/Save';
 import Transcript from 'components/Transcript'
 import Typography from '@mui/material/Typography';
 import useEventTranscript from 'hooks/useEventTranscript'
@@ -13,7 +15,7 @@ import { useRouter } from 'next/router';
 import type { Event } from 'types/Event';
 
 const EventCard: React.FC<{ event: Event }> = ({ event }) => {
-  const [transcript, refetch, error] = useEventTranscript(
+  const [transcript, refetch, error, isLoading] = useEventTranscript(
     event.id,
     event.transcript
   );
@@ -41,14 +43,32 @@ const EventCard: React.FC<{ event: Event }> = ({ event }) => {
               <Transcript transcript={transcript} />
             </Box>
           )}
-          {!isTranscript && (
+          {!isTranscript && !isLoading && (
             <Box mb={1.5}>
-              <ActionButton onClick={refetch} variant="contained" text="文字起こしする" />
+              <ActionButton
+                onClick={refetch}
+                variant='contained'
+                text='文字起こしする'
+              />
             </Box>
+          )}
+          {isLoading && (
+            <LoadingButton
+              loading
+              endIcon={<SaveIcon />}
+              loadingPosition='end'
+              variant='contained'
+            >
+              文字起こし中
+            </LoadingButton>
           )}
           {isTranscript && (
             <Box mb={1.5}>
-              <ActionButton onClick={eventDetailLink()} variant="outlined" text="詳細" />
+              <ActionButton
+                onClick={eventDetailLink()}
+                variant='outlined'
+                text='詳細'
+              />
             </Box>
           )}
           {error && (

--- a/next/src/hooks/useEventTranscript.tsx
+++ b/next/src/hooks/useEventTranscript.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 
-const useEventTranscript = (id: number, initialTranscript: string | undefined): [string, () => void, boolean] => {
+const useEventTranscript = (id: number, initialTranscript: string | undefined): [string, () => void, boolean, boolean] => {
   const [transcript, setTranscript] = useState(initialTranscript ?? "")
+  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(false)
 
   const refetch = async () => {
+    setIsLoading(true)
     const response = await fetch(`/api/events/${id}/transcript`, {
       method: 'PUT',
     });
@@ -12,12 +14,14 @@ const useEventTranscript = (id: number, initialTranscript: string | undefined): 
     const { event } = await response.json();
     if (response.ok) {
       setTranscript(event.transcript)
+      setIsLoading(false)
     } else {
       setError(true)
+      setIsLoading(false)
     }
   }
 
-  return [transcript, refetch, error]
+  return [transcript, refetch, error, isLoading]
 }
 
 export default useEventTranscript

--- a/next/src/pages/api/events/[id]/transcript.tsx
+++ b/next/src/pages/api/events/[id]/transcript.tsx
@@ -29,10 +29,15 @@ export default async function handler(
   if (event === null) { return res.status(404).json({ event: {}, error: 'event not found' })}
   if (event.transcriptUrl === "") { return res.status(404).json({ event: {}, error: 'There is not transcriptUrl' })}
 
-  const transcript = await fetchTranscript(event.transcriptUrl)
-  const updatedEvent = await prismaUpdateEvent(prisma, eventId, transcript)
+  try {
+    const transcript = await fetchTranscript(event.transcriptUrl)
+    const updatedEvent = await prismaUpdateEvent(prisma, eventId, transcript)
 
-  res.status(200).json({ event: updatedEvent })
+    res.status(200).json({ event: updatedEvent })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ event: {}, error: 'Internal Server Error' })
+  }
 }
 
 const fetchTranscript = async (url: string) => {

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -1121,6 +1121,20 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mui/base@5.0.0-alpha.101":
+  version "5.0.0-alpha.101"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.101.tgz#dba7e61716ecc946ad8cc3cba0b73796641c4022"
+  integrity sha512-a54BcXvArGOKUZ2zyS/7B9GNhAGgfomEQSkfEZ88Nc9jKvXA+Mppenfz5o4JCAnD8c4VlePmz9rKOYvvum1bZw==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@mui/types" "^7.2.0"
+    "@mui/utils" "^5.10.9"
+    "@popperjs/core" "^2.11.6"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@mui/base@5.0.0-alpha.98":
   version "5.0.0-alpha.98"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.98.tgz#d1c89477d74cbfc64a7d1b336a6dbe83d4057ee8"
@@ -1139,6 +1153,20 @@
   version "5.10.6"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.6.tgz#dd17d976a47950e7bde5bcabf52f3253ce6d62a1"
   integrity sha512-dmyQBqrKmVU6yCSM4GGal5qNXpViXX+/V1t0GA1A5i9QF5Gx6noV/cw0hrSS2ffLT8L2oScq1oTdA6NVIiQ8lg==
+
+"@mui/lab@^5.0.0-alpha.103":
+  version "5.0.0-alpha.103"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.103.tgz#c8fe493a6eb15ad56fd7d71097f727efa8dbc799"
+  integrity sha512-cYfkgSXZH/cG8BM4UGtPK0Vr9P79wfvF4S5VGiEbEsScU7yROylLZW1l11yg5nZEIVUJ7jQmcaLdlwVSTSbjzg==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@mui/base" "5.0.0-alpha.101"
+    "@mui/system" "^5.10.9"
+    "@mui/types" "^7.2.0"
+    "@mui/utils" "^5.10.9"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
 
 "@mui/material@^5.10.4":
   version "5.10.6"
@@ -1167,6 +1195,15 @@
     "@mui/utils" "^5.10.6"
     prop-types "^15.8.1"
 
+"@mui/private-theming@^5.10.9":
+  version "5.10.9"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.10.9.tgz#c427bfa736455703975cdb108dbde6a174ba7971"
+  integrity sha512-BN7/CnsVPVyBaQpDTij4uV2xGYHHHhOgpdxeYLlIu+TqnsVM7wUeF+37kXvHovxM6xmL5qoaVUD98gDC0IZnHg==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@mui/utils" "^5.10.9"
+    prop-types "^15.8.1"
+
 "@mui/styled-engine@^5.10.6":
   version "5.10.6"
   resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.10.6.tgz#9c6e79b29740e9f494c9fb26ebd4046aa88c1d21"
@@ -1175,6 +1212,16 @@
     "@babel/runtime" "^7.19.0"
     "@emotion/cache" "^11.10.3"
     csstype "^3.1.0"
+    prop-types "^15.8.1"
+
+"@mui/styled-engine@^5.10.8":
+  version "5.10.8"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.10.8.tgz#2db411e4278f06f70ccb6b5cd56ace67109513f6"
+  integrity sha512-w+y8WI18EJV6zM/q41ug19cE70JTeO6sWFsQ7tgePQFpy6ToCVPh0YLrtqxUZXSoMStW5FMw0t9fHTFAqPbngw==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@emotion/cache" "^11.10.3"
+    csstype "^3.1.1"
     prop-types "^15.8.1"
 
 "@mui/system@^5.10.6":
@@ -1191,6 +1238,20 @@
     csstype "^3.1.0"
     prop-types "^15.8.1"
 
+"@mui/system@^5.10.9":
+  version "5.10.9"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.10.9.tgz#69447a81dabbccab3c930f17d10f9aca5ba87bf1"
+  integrity sha512-B6fFC0sK06hNmqY7fAUfwShQv594+u/DT1YEFHPtK4laouTu7V4vSGQWi1WJT9Bjs9Db5D1bRDJ+Yy+tc3QOYA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@mui/private-theming" "^5.10.9"
+    "@mui/styled-engine" "^5.10.8"
+    "@mui/types" "^7.2.0"
+    "@mui/utils" "^5.10.9"
+    clsx "^1.2.1"
+    csstype "^3.1.1"
+    prop-types "^15.8.1"
+
 "@mui/types@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.0.tgz#91380c2d42420f51f404120f7a9270eadd6f5c23"
@@ -1200,6 +1261,17 @@
   version "5.10.6"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.10.6.tgz#98d432d2b05544c46efe356cf095cea3a37c2e59"
   integrity sha512-g0Qs8xN/MW2M3fLL8197h5J2VB9U+49fLlnKKqC6zy/yus5cZwdT+Gwec+wUMxgwQoxMDn+J8oDWAn28kEOR/Q==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
+"@mui/utils@^5.10.9":
+  version "5.10.9"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.10.9.tgz#9dc455f9230f43eeb81d96a9a4bdb3855bb9ea39"
+  integrity sha512-2tdHWrq3+WCy+G6TIIaFx3cg7PorXZ71P375ExuX61od1NOAJP1mK90VxQ8N4aqnj2vmO3AQDkV4oV2Ktvt4bA==
   dependencies:
     "@babel/runtime" "^7.19.0"
     "@types/prop-types" "^15.7.5"
@@ -1720,7 +1792,7 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-csstype@^3.0.2, csstype@^3.1.0:
+csstype@^3.0.2, csstype@^3.1.0, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -1154,6 +1154,13 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.6.tgz#dd17d976a47950e7bde5bcabf52f3253ce6d62a1"
   integrity sha512-dmyQBqrKmVU6yCSM4GGal5qNXpViXX+/V1t0GA1A5i9QF5Gx6noV/cw0hrSS2ffLT8L2oScq1oTdA6NVIiQ8lg==
 
+"@mui/icons-material@^5.10.9":
+  version "5.10.9"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.10.9.tgz#f9522c49797caf30146acc576e37ecb4f95bbc38"
+  integrity sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+
 "@mui/lab@^5.0.0-alpha.103":
   version "5.0.0-alpha.103"
   resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.103.tgz#c8fe493a6eb15ad56fd7d71097f727efa8dbc799"


### PR DESCRIPTION
## 概要

close: #60

## やったこと

- 文字起こしボタンを押したときに transcript が表示されるまで、スピナーを表示するようにしました
- S3 に文字起こしファイルがアップロードされていない状態で、文字起こしボタンを押したときにエラーメッセージを出すようにしました(変更前は表示されなかった)

![CleanShot 2022-10-13 at 09 47 21](https://user-images.githubusercontent.com/51867807/195473564-83779d86-513a-4ac0-b5e3-56a0de921131.png)

## やらなかったこと

- #61 の内容
  - これは後続の PR で対応します

## 動作確認方法

- 文字起こしボタンを押したときに、スピナーが表示されることを確認してください
- transcript_url が NULL なイベントの「文字起こし」ボタンをクリックして、エラーメッセージが表示されることを確認してください

## 参考