### PR TITLE
[Bot] 音声ファイルを入力&出力する際の Path の指定が誤っていたため

### DIFF
--- a/discord_bot/index.ts
+++ b/discord_bot/index.ts
@@ -1,0 +1,1 @@
+import './src/bot/bot'

--- a/discord_bot/src/index.ts
+++ b/discord_bot/src/index.ts
@@ -1,1 +1,0 @@
-import './bot/bot'

--- a/discord_bot/src/utils/listeningStream.ts
+++ b/discord_bot/src/utils/listeningStream.ts
@@ -13,7 +13,7 @@ const getDisplayName = (userId: string, user?: User) => {
 
 const createOutputFile = (userId: string, user?: User) => {
   const fileDir = getFileDir(import.meta.url)
-  return path.resolve(fileDir, `../../recordings/${Date.now()}-${getDisplayName(userId, user)}.ogg`)
+  return path.resolve(fileDir, `../../../recordings/${Date.now()}-${getDisplayName(userId, user)}.ogg`)
 }
 
 export const createListeningStream = (receiver: VoiceReceiver, userId: string, user?: User) => {

--- a/discord_bot/src/utils/oggFile.ts
+++ b/discord_bot/src/utils/oggFile.ts
@@ -5,7 +5,7 @@ import { deleteFiles, getFileDir } from './file'
 
 export const mergeOggFiles = async () => {
   const fileDir = getFileDir(import.meta.url)
-  const recordingDir = path.resolve(fileDir, '../../recordings')
+  const recordingDir = path.resolve(fileDir, '../../../recordings')
 
   const oggFiles = await getOggFiles(recordingDir)
   const opts = { output: './recorded_outputs/result', export: 'ogg' }

--- a/discord_bot/src/utils/s3Controller.ts
+++ b/discord_bot/src/utils/s3Controller.ts
@@ -27,7 +27,7 @@ export const uploadAudioFileToS3 = async (fileKey: string, fileName: string) => 
 export const uploadRecordedOggFile = async (title: string, fileName: string): Promise<string> => {
   const fileKey = `${fileName}.ogg`
   const audioUrl = `s3://${bucketName}/${fileKey}`
-  const recordedFile = path.resolve(getFileDir(import.meta.url), '../../recorded_outputs/result.ogg')
+  const recordedFile = path.resolve(getFileDir(import.meta.url), '../../../recorded_outputs/result.ogg')
 
   try {
     await uploadAudioFileToS3(fileKey, recordedFile)

--- a/discord_bot/tsconfig.json
+++ b/discord_bot/tsconfig.json
@@ -19,6 +19,7 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
+    "./index.ts",
     "./src/**/*.ts"
   ]
 }


### PR DESCRIPTION
## 起こった問題
- 本番環境で Discord Bot を起動するために yarn install をすると下記のエラーで落ちてしまった

<details>
<summary>エラーログ</summary>

```console
> $ node --experimental-specifier-resolution=node dist/index.js
> (node:33) ExperimentalWarning: The Node.js specifier resolution flag is experimental. It could change or be removed at any time.
> (Use `node --trace-warnings ...` to show where the warning was created)
> node:internal/errors:478
> ErrorCaptureStackTrace(err);
> ^
> 
> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/dist/index.js' imported from /app/
> at new NodeError (node:internal/errors:387:5)
> at finalizeResolution (node:internal/modules/esm/resolve:315:15)
> at moduleResolve (node:internal/modules/esm/resolve:907:10)
> at defaultResolve (node:internal/modules/esm/resolve:1115:11)
> at nextResolve (node:internal/modules/esm/loader:163:28)
> at ESMLoader.resolve (node:internal/modules/esm/loader:837:30)
> at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
> at ESMLoader.import (node:internal/modules/esm/loader:521:22)
> at node:internal/modules/run_main:58:28
> at loadESM (node:internal/process/esm_loader:91:11) {
> code: 'ERR_MODULE_NOT_FOUND'
> }
> error Command failed with exit code 1.
> info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

## 原因
- yarn start で起点となるファイルパスが誤っていた

## やったこと
- yarn start で起点となるファイルを変更した
- 上記のエラーの解決に伴い、音声ファイルへのパスが変更になったため修正

## 動作確認
- 本番環境でペアで作業を行いました
    - Bot が起動すること
    - 録音ファイルの生成と結合が問題なく行えること 